### PR TITLE
Sync with wordpress.org & version 1.4.3 (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 package-lock.json
 node_modules/
+.DS_Store

--- a/classes/admin/class-site-health.php
+++ b/classes/admin/class-site-health.php
@@ -4,7 +4,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2018-04-25 17:08:45
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2023-05-05 14:26:25
+ * @Last Modified time: 2023-05-25 09:51:16
  */
 
 namespace CRMServiceWP\Admin\SiteHealth;
@@ -181,6 +181,10 @@ class SiteHealth extends CRMServiceWP\Plugin {
       'actions'     => '',
       'test'        => 'crmservice_failed_submissions',
     );
+
+    if ( ! self::$helper->check_if_form_plugin_active() ) {
+      return $result;
+    }
 
     $form_plugin_slug = self::$helper->get_form_plugin( true );
     $failed_submissions = self::$form_plugin_instance->get_failed_submissions();

--- a/crm-service.php
+++ b/crm-service.php
@@ -11,9 +11,9 @@
  * Author URI:        https://crm-service.fi/
  * License:           GPLv2
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Version:           1.4.0
+ * Version:           1.4.3
  * Requires at least: 4.9
- * Tested up to:      6.2
+ * Tested up to:      6.3
  *
  * Text Domain: crmservice
  * Domain Path: /languages
@@ -21,7 +21,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2018-02-27 15:47:00
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2023-05-09 11:14:23
+ * @Last Modified time: 2023-09-04 14:33:04
  */
 
 namespace CRMServiceWP;
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! class_exists( 'Plugin' ) ) :
-  define( 'CRMSERVICEWP_VERSION', '1.4.0' );
+  define( 'CRMSERVICEWP_VERSION', '1.4.3' );
 
   /**
    *  Main class for plugin.
@@ -163,4 +163,3 @@ endif;
 // Add plugin activation and deactivation hooks.
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\plugin_activation' );
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\plugin_deactivation' );
-

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: crmservice
 Tags: crm, crm-service, crm service
 Requires at least: 4.9
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.0
-Stable tag: 1.4.0
+Stable tag: 1.4.3
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -55,6 +55,21 @@ If you need a support for spesific form plugin, [contact us](https://crm-service
 All notable changes to this project will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+= 1.4.3 =
+Release date: 2023-09-04
+
+* Instead of listing saved connections, list all form fields and check if there is already a connection made. This allows modifying and adding new connections when form fields changes after making the first connections.
+
+= 1.4.2 =
+Release date: 2023-05-26
+
+* Fix fatal error if headign to site health right after installing the plugin
+
+= 1.4.1 =
+Release date: 2023-05-26
+
+* Fix release
 
 = 1.4.0 =
 Release date: 2023-04-09

--- a/views/admin/metabox-integration-settings.php
+++ b/views/admin/metabox-integration-settings.php
@@ -5,7 +5,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2018-03-30 14:10:28
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2019-07-01 15:30:49
+ * @Last Modified time: 2023-09-04 14:32:37
  *
  * @package crmservice
  */
@@ -15,185 +15,193 @@ namespace CRMServiceWP;
 use CRMServiceWP\Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit();
+  exit();
 }
 
 \wp_nonce_field( 'crmservice_integration_nonce', 'crmservice_nonce' );
 // save form plugin! ?>
 
 <div class="crmservice-metabox-settings-wrap">
-	<div class="row row-setting">
-		<div class="col col-form">
-			<p class="label"><?php \esc_attr_e( 'Form', 'crmservice' ); ?></p>
+  <div class="row row-setting">
+    <div class="col col-form">
+      <p class="label"><?php \esc_attr_e( 'Form', 'crmservice' ); ?></p>
 
-			<?php if ( empty( $forms ) ) : ?>
-				<p>
+      <?php if ( empty( $forms ) ) : ?>
+        <p>
           <?php printf( \wp_kses( \__( 'You don\'t have any forms yet. Create a <a href="%s">new form</a>.', 'crmservice' ), array(
-						'a' => array(
-						'href' => array(),
-					), ) ), \esc_url( $new_form_url ) ) ?>
-				</p>
-			<?php else : ?>
-				<div class="select-wrapper">
-					<select name="crmservice_form" class="crmservice-form">
-						<option value="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
-						<?php foreach ( $forms as $form_id => $form ) : ?>
-							<option value="<?php echo $form_id; ?>"<?php if ( (int) $form_id === (int) $saved_form ) { echo ' selected'; } ?>><?php echo $form; ?></option>
-						<?php endforeach; ?>
-					</select>
-				</div>
-			<?php endif; ?>
-		</div>
+            'a' => array(
+            'href' => array(),
+          ), ) ), \esc_url( $new_form_url ) ) ?>
+        </p>
+      <?php else : ?>
+        <div class="select-wrapper">
+          <select name="crmservice_form" class="crmservice-form">
+            <option value="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+            <?php foreach ( $forms as $form_id => $form ) : ?>
+              <option value="<?php echo $form_id; ?>"<?php if ( (int) $form_id === (int) $saved_form ) { echo ' selected'; } ?>><?php echo $form; ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+      <?php endif; ?>
+    </div>
 
-		<div class="col col-module">
-			<p class="label"><?php \esc_attr_e( 'CRM Module', 'crmservice' ); ?></p>
+    <div class="col col-module">
+      <p class="label"><?php \esc_attr_e( 'CRM Module', 'crmservice' ); ?></p>
 
-			<?php if ( empty( $crm_modules ) ) : ?>
-				<p><?php \esc_attr_e( 'No modules found, please contact your CRM-service provider.', 'crmservice' ); ?></p>
-			<?php else : ?>
-				<div class="select-wrapper">
-					<select name="crmservice_module">
-						<option value="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
-						<?php foreach ( $crm_modules as $module_id => $module ) : ?>
-							<option value="<?php echo $module; ?>"<?php if ( $module === $saved_module ) { echo ' selected'; } ?>><?php echo $module; ?></option>
-						<?php endforeach; ?>
-					</select>
-				</div>
-			<?php endif; ?>
-		</div>
-	</div>
+      <?php if ( empty( $crm_modules ) ) : ?>
+        <p><?php \esc_attr_e( 'No modules found, please contact your CRM-service provider.', 'crmservice' ); ?></p>
+      <?php else : ?>
+        <div class="select-wrapper">
+          <select name="crmservice_module">
+            <option value="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+            <?php foreach ( $crm_modules as $module_id => $module ) : ?>
+              <option value="<?php echo $module; ?>"<?php if ( $module === $saved_module ) { echo ' selected'; } ?>><?php echo $module; ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
 </div>
 
 <div class="crmservice-metabox-connections-wrap" <?php if ( empty( $saved_conections ) ) : ?>style="display:none;"<?php endif; ?>>
-	<h3><?php \esc_attr_e( 'Field mapping', 'crmservice' ); ?></h3>
+  <h3><?php \esc_attr_e( 'Field mapping', 'crmservice' ); ?></h3>
 
-	<div class="row row-head">
-		<div class="col col-form">
-			<p><?php \esc_attr_e( 'Form field', 'crmservice' ); ?></p>
-		</div>
-		<div class="col col-module">
-			<p><?php \esc_attr_e( 'Module field', 'crmservice' ); ?></p>
-		</div>
-	</div>
+  <div class="row row-head">
+    <div class="col col-form">
+      <p><?php \esc_attr_e( 'Form field', 'crmservice' ); ?></p>
+    </div>
+    <div class="col col-module">
+      <p><?php \esc_attr_e( 'Module field', 'crmservice' ); ?></p>
+    </div>
+  </div>
 
-	<div id="form-row-0" class="row row-field row-field-base" style="display:none;">
-		<div class="col col-form">
-			<p></p>
-			<input type="hidden" name="form_field" value="" />
-		</div>
-		<div class="col col-module">
-			<div class="select-wrapper">
-				<select name="module_field">
-					<option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
-				</select>
-			</div>
-			<input type="hidden" name="module_field" value="0" />
-			<p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
-			<p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
-		</div>
-	</div>
+  <div id="form-row-0" class="row row-field row-field-base" style="display:none;">
+    <div class="col col-form">
+      <p></p>
+      <input type="hidden" name="form_field" value="" />
+    </div>
+    <div class="col col-module">
+      <div class="select-wrapper">
+        <select name="module_field">
+          <option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+        </select>
+      </div>
+      <input type="hidden" name="module_field" value="0" />
+      <p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
+      <p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
+    </div>
+  </div>
 
-	<?php if ( ! empty( $saved_conections ) ) :
-		foreach ( $saved_conections as $connection_id => $connection ) :
-			if ( ! isset( $form_fields['fields'][ $connection['form_field'] ] ) ) {
-				continue;
-			} ?>
+  <?php if ( ! empty( $saved_conections ) ) :
+    $x = 1;
+    foreach ( $form_fields['fields'] as $form_field_key => $form_field ) :
+      $field_connection = null;
 
-			<div id="form-row-<?php echo $connection_id; ?>" class="row row-field">
-				<div class="col col-form">
-					<p><?php echo $form_fields['fields'][ $connection['form_field'] ]; ?></p>
-					<input type="hidden" name="crmservice_connections[<?php echo $connection_id; ?>][form_field]" value="<?php echo $connection['form_field']; ?>" />
-				</div>
-				<div class="col col-module">
-					<?php if ( ! empty( $module_fields ) ) : ?>
-						<div class="select-wrapper">
-							<select name="crmservice_connections[<?php echo $connection_id; ?>][module_field]">
-								<option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+      foreach ( $saved_conections as $connection ) {
+        if ( absint( $form_field_key ) !== absint( $connection['form_field'] ) ) {
+          continue;
+        }
 
-								<?php foreach ( $module_fields as $module_field_id => $module_field ) : ?>
-									<option value="<?php echo $module_field->name; ?>" data-type="<?php echo $module_field->type; ?>" data-uitype="<?php echo $module_field->uitype; ?>" <?php if ( isset( $connection['module_field'] ) && $connection['module_field'] === $module_field->name ) { echo ' selected'; } ?>><?php echo $module_field->label; ?> (<?php echo $module_field->type; ?>)</option>
-								<?php endforeach; ?>
-							</select>
-						</div>
-						<input type="hidden" name="crmservice_connections[<?php echo $connection_id; ?>][module_field]" value="<?php if ( isset( $connection['module_field'] ) ) { echo $connection['module_field']; } ?>" />
+        $field_connection = $connection;
+      }
 
-						<p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
-						<p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
-					<?php endif; ?>
-				</div>
-			</div>
-		<?php endforeach; ?>
-	<?php endif; ?>
+       ?>
+      <div id="form-row-<?php echo $x; ?>" class="row row-field">
+        <div class="col col-form">
+          <p><?php echo $form_field; ?></p>
+          <input type="hidden" name="crmservice_connections[<?php echo $x; ?>][form_field]" value="<?php echo $form_field_key; ?>" />
+        </div>
+        <div class="col col-module">
+          <?php if ( ! empty( $module_fields ) ) : ?>
+            <div class="select-wrapper">
+              <select name="crmservice_connections[<?php echo $x; ?>][module_field]">
+                <option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+
+                <?php foreach ( $module_fields as $module_field_id => $module_field ) : ?>
+                  <option value="<?php echo $module_field->name; ?>" data-type="<?php echo $module_field->type; ?>" data-uitype="<?php echo $module_field->uitype; ?>" <?php if ( $field_connection && $field_connection['module_field'] === $module_field->name ) { echo ' selected'; } ?>><?php echo $module_field->label; ?> (<?php echo $module_field->type; ?>)</option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <input type="hidden" name="crmservice_connections[<?php echo $x; ?>][module_field]" value="<?php if ( isset( $field_connection['module_field'] ) ) { echo $field_connection['module_field']; } ?>" />
+
+            <p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
+            <p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
+          <?php endif; ?>
+        </div>
+      </div>
+    <?php $x++; endforeach; ?>
+  <?php endif; ?>
 </div>
 
 <div class="crmservice-metabox-static-fields-wrap" <?php if ( empty( $saved_conections ) ) : ?>style="display:none;"<?php endif; ?>>
-	<h3><?php \esc_attr_e( 'Pre-filled module fields', 'crmservice' ); ?></h3>
+  <h3><?php \esc_attr_e( 'Pre-filled module fields', 'crmservice' ); ?></h3>
 
-	<div class="row row-head" <?php if ( empty( $saved_static_fields ) ) : ?>style="display:none;"<?php endif; ?>>
-		<div class="col col-module">
-			<p><?php \esc_attr_e( 'Module field', 'crmservice' ); ?></p>
-		</div>
-		<div class="col col-value">
-			<p><?php \esc_attr_e( 'Value', 'crmservice' ); ?></p>
-		</div>
-	</div>
+  <div class="row row-head" <?php if ( empty( $saved_static_fields ) ) : ?>style="display:none;"<?php endif; ?>>
+    <div class="col col-module">
+      <p><?php \esc_attr_e( 'Module field', 'crmservice' ); ?></p>
+    </div>
+    <div class="col col-value">
+      <p><?php \esc_attr_e( 'Value', 'crmservice' ); ?></p>
+    </div>
+  </div>
 
-	<div id="form-row-0" class="row row-field row-field-base" style="display:none;">
-		<div class="col col-module">
-			<div class="select-wrapper">
-				<?php if ( ! empty( $module_fields ) ) : ?>
-					<select name="crmservice_static_fields[0]">
-						<option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+  <div id="form-row-0" class="row row-field row-field-base" style="display:none;">
+    <div class="col col-module">
+      <div class="select-wrapper">
+        <?php if ( ! empty( $module_fields ) ) : ?>
+          <select name="crmservice_static_fields[0]">
+            <option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
 
-						<?php foreach ( $module_fields as $module_field_id => $module_field ) : ?>
-							<option value="<?php echo $module_field->name; ?>" data-type="<?php echo $module_field->type; ?>"  data-uitype="<?php echo $module_field->uitype; ?>" ><?php echo $module_field->label; ?> (<?php echo $module_field->type; ?>)</option>
-						<?php endforeach; ?>
-					</select>
-				<?php else : ?>
-					<select name="crmservice_static_fields[0]">
-						<option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
-					</select>
-				<?php endif; ?>
-				<input type="hidden" name="crmservice_static_fields[0]" value="" />
-			</div>
-			<p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
-			<p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
-		</div>
-		<div class="col col-value">
-			<input type="text" name="crmservice_static_fields_values[0]" value="" />
-			<button class="delete"><span class="dashicons dashicons-no-alt"></span></button>
-		</div>
-	</div>
+            <?php foreach ( $module_fields as $module_field_id => $module_field ) : ?>
+              <option value="<?php echo $module_field->name; ?>" data-type="<?php echo $module_field->type; ?>"  data-uitype="<?php echo $module_field->uitype; ?>" ><?php echo $module_field->label; ?> (<?php echo $module_field->type; ?>)</option>
+            <?php endforeach; ?>
+          </select>
+        <?php else : ?>
+          <select name="crmservice_static_fields[0]">
+            <option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+          </select>
+        <?php endif; ?>
+        <input type="hidden" name="crmservice_static_fields[0]" value="" />
+      </div>
+      <p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
+      <p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
+    </div>
+    <div class="col col-value">
+      <input type="text" name="crmservice_static_fields_values[0]" value="" />
+      <button class="delete"><span class="dashicons dashicons-no-alt"></span></button>
+    </div>
+  </div>
 
-	<?php if ( ! empty( $saved_static_fields ) ) :
-		foreach ( $saved_static_fields as $field_id => $field_value ) : ?>
+  <?php if ( ! empty( $saved_static_fields ) ) :
+    foreach ( $saved_static_fields as $field_id => $field_value ) : ?>
 
-			<div id="form-row-<?php echo $field_id; ?>" class="row row-field">
-				<div class="col col-module">
-					<?php if ( ! empty( $module_fields ) ) : ?>
-						<div class="select-wrapper">
-							<select name="crmservice_static_fields[<?php echo $field_id; ?>]">
-								<option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
+      <div id="form-row-<?php echo $field_id; ?>" class="row row-field">
+        <div class="col col-module">
+          <?php if ( ! empty( $module_fields ) ) : ?>
+            <div class="select-wrapper">
+              <select name="crmservice_static_fields[<?php echo $field_id; ?>]">
+                <option value="0" data-type="0" data-uitype="0"><?php \esc_attr_e( 'Select', 'crmservice' ); ?></option>
 
-								<?php foreach ( $module_fields as $module_field_id => $module_field ) : ?>
-									<option value="<?php echo $module_field->name; ?>" data-type="<?php echo $module_field->type; ?>"  data-uitype="<?php echo $module_field->uitype; ?>" <?php if ( $field_id === $module_field->name ) { echo ' selected'; } ?>><?php echo $module_field->label; ?> (<?php echo $module_field->type; ?>)</option>
-								<?php endforeach; ?>
-							</select>
-							<input type="hidden" name="crmservice_static_fields[<?php echo $field_id; ?>]" value="<?php echo $field_id; ?>" />
-						</div>
-						<p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
-						<p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
-					<?php endif; ?>
-				</div>
-				<div class="col col-value">
-					<input type="text" name="crmservice_static_fields_values[<?php echo $field_id; ?>]" value="<?php echo $field_value; ?>" />
-					<button class="delete"><span class="dashicons dashicons-no-alt"></span></button>
-				</div>
-			</div>
-		<?php endforeach; ?>
-	<?php endif; ?>
+                <?php foreach ( $module_fields as $module_field_id => $module_field ) : ?>
+                  <option value="<?php echo $module_field->name; ?>" data-type="<?php echo $module_field->type; ?>"  data-uitype="<?php echo $module_field->uitype; ?>" <?php if ( $field_id === $module_field->name ) { echo ' selected'; } ?>><?php echo $module_field->label; ?> (<?php echo $module_field->type; ?>)</option>
+                <?php endforeach; ?>
+              </select>
+              <input type="hidden" name="crmservice_static_fields[<?php echo $field_id; ?>]" value="<?php echo $field_id; ?>" />
+            </div>
+            <p class="select-options"><?php \esc_attr_e( 'Possible values:', 'crmservice' ); ?> <span></span></p>
+            <p class="uitype-user-relation"><?php \esc_attr_e( 'Field is for user relation and value needs to be valid user ID.', 'crmservice' ); ?></p>
+          <?php endif; ?>
+        </div>
+        <div class="col col-value">
+          <input type="text" name="crmservice_static_fields_values[<?php echo $field_id; ?>]" value="<?php echo $field_value; ?>" />
+          <button class="delete"><span class="dashicons dashicons-no-alt"></span></button>
+        </div>
+      </div>
+    <?php endforeach; ?>
+  <?php endif; ?>
 
-	<div class="row row-footer">
-		<button class="button button-medium"><?php \esc_attr_e( 'Add new pre-filled field', 'crmservice' ); ?></button>
-	</div>
+  <div class="row row-footer">
+    <button class="button button-medium"><?php \esc_attr_e( 'Add new pre-filled field', 'crmservice' ); ?></button>
+  </div>
 </div>


### PR DESCRIPTION
* fix php notice when form plugin is not yet selected

* fix multitude of php errors and warnings when form plugin not active, fixes #15

* change the bug report email to

* add api health check to site health

* add form plugin site health test

* add CF7 Flamingo test to form tests in site health

* add failed submission tests to site health

* do not save send fail before we have actually tried to send the data to crm-service

* bump plugin version to 1.4.0

* bump version to 1.4.1

* sync with wp.org

* Instead of listing saved connections, list all form fields and check if there is already a connection made. This allows modifying and adding new connections when form fields changes after making the first connections.

* bump version to 1.4.3